### PR TITLE
Improve Buffer.incr docstrings

### DIFF
--- a/src/sentry/buffer/base.py
+++ b/src/sentry/buffer/base.py
@@ -102,12 +102,18 @@ class Buffer(Service):
         extra: dict[str, Any] | None = None,
         signal_only: bool | None = None,
     ) -> None:
-        """
-        >>> incr(Group, columns={'times_seen': 1}, filters={'pk': group.pk})
-        signal_only - added to indicate that `process` should only call the complete
-        signal handler with the updated model and skip creates/updates in the database. this
-        is useful in cases where we need to do additional processing before writing to the
-        database and opt to do it in a `buffer_incr_complete` receiver.
+        """Queue an increment operation for ``model``.
+
+        ``columns`` is a mapping of field names to the values that should be
+        incremented atomically. ``filters`` identifies the row to update.
+        ``extra`` allows setting additional columns directly when the buffered
+        values are flushed. Set ``signal_only`` to ``True`` to skip database
+        writes and only emit the ``buffer_incr_complete`` signal. This can be
+        useful when additional work needs to be done before persisting changes.
+
+        Example::
+
+            incr(Group, columns={"times_seen": 1}, filters={"pk": group.pk})
         """
         process_incr.apply_async(
             kwargs={

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -2209,6 +2209,9 @@ def _process_existing_aggregate(
         "title": _get_updated_group_title(existing_metadata, incoming_metadata),
     }
 
+    # ``times_seen`` must be provided via ``columns`` so that ``Buffer.incr``
+    # performs an atomic increment. The rest of the updated values are passed
+    # through ``extra`` which sets them directly on the model.
     update_kwargs = {"times_seen": 1}
 
     buffer_incr(Group, update_kwargs, {"id": group.id}, updated_group_values)

--- a/src/sentry/tasks/process_buffer.py
+++ b/src/sentry/tasks/process_buffer.py
@@ -66,10 +66,16 @@ def process_incr(**kwargs):
 
 
 def buffer_incr(model, *args, **kwargs):
-    """
-    Call `buffer.incr` task, resolving the model name first.
+    """Schedule :func:`buffer.incr` for the given ``model``.
 
-    `model_name` must be in form `app_label.model_name` e.g. `sentry.group`.
+    ``args`` and ``kwargs`` mirror the parameters of :meth:`Buffer.incr`. The most
+    common keyword arguments are ``columns`` (a mapping of column names to
+    increments), ``filters`` (used to identify the row to update), ``extra``
+    (additional columns to set directly), and ``signal_only`` (skip database
+    writes and only emit the ``buffer_incr_complete`` signal).
+
+    If ``SENTRY_BUFFER_INCR_AS_CELERY_TASK`` is enabled the call is queued via
+    Celery, otherwise it runs inline.
     """
     (buffer_incr_task.delay if settings.SENTRY_BUFFER_INCR_AS_CELERY_TASK else buffer_incr_task)(
         app_label=model._meta.app_label, model_name=model._meta.model_name, args=args, kwargs=kwargs
@@ -81,8 +87,11 @@ def buffer_incr(model, *args, **kwargs):
     queue="buffers.incr",
 )
 def buffer_incr_task(app_label, model_name, args, kwargs):
-    """
-    Call `buffer.incr`, resolving the model first.
+    """Execute :meth:`Buffer.incr` for ``app_label.model_name``.
+
+    ``model_name`` should be the lowercase model identifier as provided by
+    Django's ``Model._meta.model_name`` attribute. ``args`` and ``kwargs`` are
+    forwarded directly to :meth:`Buffer.incr`.
     """
     from sentry import buffer
 


### PR DESCRIPTION
## Summary
- clarify usage of Buffer.incr
- document parameters for `buffer_incr` and `buffer_incr_task`
- note why `times_seen` is incremented separately when storing groups

## Testing
- `python3 -m pytest tests/sentry/tasks/test_process_buffer.py::BufferIncrTest::test_buffer_incr_task -q` *(fails: No module named pytest)*